### PR TITLE
card bug demo fixes

### DIFF
--- a/video-cta.html
+++ b/video-cta.html
@@ -21,23 +21,13 @@
     <div class="cds--css-grid">
       <div class="cds--col-span-25 cds--css-grid-column">
         <c4d-card
-          aspect-ratio="2:1"
           cta-type="video"
-          color-scheme=""
           href="0_ibuqxqbe"
-          size=""
-          pictogram-placement="bottom"
         >
           <c4d-card-eyebrow>Industry</c4d-card-eyebrow>
           <c4d-card-heading>Custom video title</c4d-card-heading>
           <c4d-card-footer
             cta-type="video"
-            icon-placement="right"
-            color-scheme=""
-            slot="footer"
-            parent-href="0_ibuqxqbe"
-            video-name="FELIPE'S TEST - Meet Mombo, a different IBM Manager"
-            video-duration="160"
           ></c4d-card-footer>
         </c4d-card>
       </div>
@@ -46,11 +36,8 @@
         <c4d-card-group-item
           cta-type="video"
           href="0_ibuqxqbe"
-          size=""
-          color-scheme=""
-          pictogram-placement="bottom"
         >
-          <c4d-card-eyebrow slot="eyebrow">Topic</c4d-card-eyebrow>
+          <c4d-card-eyebrow>Topic</c4d-card-eyebrow>
           <c4d-card-heading>Custom Title</c4d-card-heading>
 
           <div>
@@ -60,14 +47,7 @@
 
           <c4d-card-footer
             cta-type="video"
-            slot="footer"
-            href="0_ibuqxqbe"
-            icon-placement="right"
-            color-scheme=""
-            parent-href="0_ibuqxqbe"
-            video-name="FELIPE'S TEST - Meet Mombo, a different IBM Manager"
-            video-duration="160"
-          >Footer</c4d-card-footer>
+          ></c4d-card-footer>
         </c4d-card-group-item>
       </div>
 
@@ -75,21 +55,22 @@
         <c4d-cta
           cta-style="card"
           cta-type="video"
-          video-name="Custom video title"
-          video-description="This is a custom video description"
           href="0_ibuqxqbe"
-        ></c4d-cta>
+        >
+          <c4d-card-heading></c4d-card-heading>
+          <c4d-card-cta-footer cta-type="video"></c4d-card-cta-footer>
+        </c4d-cta>
       </div>
 
       <div class="cds--col-span-25 cds--css-grid-column" style="margin-top: 1rem">
         <c4d-cta
           cta-style="card-link"
           cta-type="video"
-          video-name="Custom video title"
-          video-description="This is a custom video description"
           href="0_ibuqxqbe"
-          data-autoid="c4d-cta"
-        ></c4d-cta>
+        >
+          <c4d-card-heading></c4d-card-heading>
+          <c4d-card-cta-footer cta-type="video"></c4d-card-cta-footer>
+        </c4d-cta>
       </div>
     </div>
   </c4d-video-cta-container>


### PR DESCRIPTION
Shows some adjustments to the demo:

* Remove redundant attributes that use default values and/or are added automatically
* Remove video name and duration attributes to start all cards from a common base
* Add expected child markup for the cards