### PR TITLE
chore: use next version instead of PR preview

### DIFF
--- a/scripts/prestart.js
+++ b/scripts/prestart.js
@@ -1,17 +1,17 @@
 import { glob } from "glob";
 import { writeFile } from "fs/promises"
 
-const cibm = "https://ibmdotcom-cdn.s3.us-east.cloud-object-storage.appdomain.cloud/deploy-previews/12063"
+const cibm = "https://1.www.s81c.com/common/carbon-for-ibm-dotcom/version";
 const cwc = "https://1.www.s81c.com/common/carbon/web-components/version";
 
 (async () => {
   const cibm_pkg = await fetch('https://registry.npmjs.org/@carbon/ibmdotcom-web-components').then(r => r.json());
-  const cibm_version = cibm_pkg["dist-tags"].latest;
+  const cibm_version = cibm_pkg["dist-tags"].next;
 
   const cibm_components = await glob('./node_modules/@carbon/ibmdotcom-web-components/es/components/*/index.js');
   const cibm_imports = cibm_components
     .map(path => path.split('/').at(-2))
-    .map(cmp => `import "${cibm}/${cmp}.min.js";`)
+    .map(cmp => `import "${cibm}/v${cibm_version}/${cmp}.min.js";`)
     .join('\n');
 
 


### PR DESCRIPTION
Adjust the card group subgrid demo to use the next version (eg. v2.14.0-rc.0 at time of writing).